### PR TITLE
Fix hardcoded addresses so that the kernel can be linked to 1M again

### DIFF
--- a/src/arch/x86_64/interrupt_table.asm
+++ b/src/arch/x86_64/interrupt_table.asm
@@ -14,7 +14,7 @@ section .data
 %macro IDT_ENTRY 1
     extern interrupt_handler_%1
     ;TODO: remove the word data exceeds bounds warning
-    DW (interrupt_handler_%1 - 0x200000)  ;offset_low
+    DW (interrupt_handler_%1 - 0x100000)  ;offset_low
     DW 0x8              ;text segment
 
     %ifdef H%1_IST
@@ -24,7 +24,7 @@ section .data
     %endif
 
     DB 0x8e             ;type_addr: present+interrupt_gate
-    DW 0x20             ;offset_middle
+    DW 0x10             ;offset_middle
     DQ 0                ;offset_high and zero2
 %endmacro
 

--- a/src/arch/x86_64/linker.ld
+++ b/src/arch/x86_64/linker.ld
@@ -1,48 +1,22 @@
-
 ENTRY(start)
 
-kernel_stack_size = 1M;
-
 SECTIONS {
-
-    /* somehow needed for grub to recognize the multiboot header */
-    . = 2M + SIZEOF_HEADERS;
+    . = 1M;
 
     .boot :
     {
         /* ensure that the multiboot header is at the beginning */
         KEEP(*(.multiboot_header))
 
-        /* ensure that the address (tss-0x200000) fits in 16bit */
+        /* ensure that the address (tss-0x100000) fits in 16bit */
         *(.tss)
-        /* ensure that the address (interrupt_handlers-0x200000) fits in 16bit*/
+        /* ensure that the address (interrupt_handlers-0x100000) fits in 16bit*/
         *(.interrupt_handlers)
     }
 
     .text :
     {
-      *(.text .text.*)
+        *(.boot)
+        *(.text)
     }
-
-    .rodata :
-    {
-      *(.rodata .rodata.*)
-    }
-
-    .data.rel.ro :
-    {
-      *(.data.rel.ro .data.rel.ro.*)
-    }
-
-    .data :
-    {
-      *(.data .data.*)
-    }
-
-    kernel_stack_bottom = .;
-    . += kernel_stack_size;
-    . = ALIGN(16);
-    kernel_stack_top = .;
-
 }
-


### PR DESCRIPTION
The `offset_middle` field is hardcoded and needs to be adjusted to 1 instead of 2. Similarly, we need to subtract `0x100000` instead of `0x200000`.

We still need to add the sections to the `.boot` output section so that `offset_middle` stays 1, even if our kernel grows significantly. The rest of the linker script is reverted to the previous version.